### PR TITLE
Fix login sending users to 'undefined'

### DIFF
--- a/extra-assets/js/login.js
+++ b/extra-assets/js/login.js
@@ -1,19 +1,3 @@
-function redirectIfNeeded() {
-    // Only redirect utoronto.2i2c.cloud, lets us keep staging at staging.utoronto.2i2c.cloud
-    if (window.location.hostname === 'utoronto.2i2c.cloud') {
-        // Let's give users an indication that something is happening
-        document.write("Redirecting you to jupyter.utoronto.ca");
-        window.location.hostname = 'jupyter.utoronto.ca';
-    }
-}
-function setInterface(interfaceUrl) {
-    let loginUrl = new URL($('#home').data('authenticator-login-url'), document.location.origin);
-    loginUrl.searchParams.set('next', '/hub/user-redirect/' + interfaceUrl)
-    $('#login-button').attr(
-        'href',
-        loginUrl.toString()
-    );
-}
 function showDiscalimerModal() {
     var HUB_MODAL_STORAGE_KEY = 'humModalDismissed';
     var showModal = localStorage.getItem(HUB_MODAL_STORAGE_KEY) === null? true: !(localStorage.getItem(HUB_MODAL_STORAGE_KEY) === 'true');
@@ -26,19 +10,6 @@ function showDiscalimerModal() {
     })
 }
 $(function() {
-    redirectIfNeeded();
-    // if next query param is presentm just do nothing
-    const nextPresent = new URL(document.location).searchParams.get('next');
-    // /hub/ being next should be treated same as no next present
-    if (!nextPresent || nextPresent === "/hub/") {
-        setInterface($("input[name='interface']:checked").val());
-
-        $("input[name='interface']").change(function() {
-            if (this.checked) {
-                setInterface(this.value)
-            }
-        });
-    }
     /* show disclaimer modal */
     showDiscalimerModal()
 })

--- a/templates/login.html
+++ b/templates/login.html
@@ -71,41 +71,9 @@
         <span id="new-user"> New user? </span> Please see our documentation about <a href="https://us-ghg-center.github.io/ghgc-docs/services/jupyterhub.html">how to request access</a>.
       </p>
     <div class="login-container text-center">
-      {% if "interface_selector" in custom and custom["interface_selector"] and (not next or next == "%2Fhub%2F") %}
-      <form class="form-inline">
-        <div class="form-group interface-selector">
-          <label>After logging in, open: </label>
-          <label class="radio-inline">
-            <input type="radio" name="interface" value="tree"
-                   {% if "default_url" not in custom or custom["default_url"] == "/tree" %}
-                   checked
-                   {% endif %}
-                   >Jupyter Notebook
-          </label>
-          <label class="radio-inline">
-            <input type="radio" name="interface" value="rstudio"
-                   {% if "default_url" in custom and custom["default_url"] == "/rstudio" %}
-                   checked
-                   {% endif %}
-                   >RStudio
-          </label>
-          <label class="radio-inline">
-            <input type="radio" name="interface" value="lab"
-                   {% if "default_url" in custom and custom["default_url"] == "/lab" %}
-                   checked
-                   {% endif %}
-                   >JupyterLab
-          </label>
-        </div>
-      </form>
-      <a role="button" id="login-button" class='btn btn-jupyter btn-lg' href='{{authenticator_login_url}}'>
-        Log in to start
-      </a>
-      {% else %}
       <a role="button" id="login-button" class='btn btn-jupyter btn-lg' href='{{authenticator_login_url}}'>
         Log in to continue
       </a>
-      {% endif %}
     </div>
   
   </div>


### PR DESCRIPTION
- Remove code for interface selector, which is unused. Interaction between the modal dialog and this is probably the cause of users logging in being sent to an 'undefined' page
- Remove unneeded redirectIfNeeded
- Cleanup the JS and HTML code so further modification by others is easier! GHG can have as customized a front page as it wants