### PR TITLE
Make the ghg staging hub homepage bootstrap5 compatible

### DIFF
--- a/extra-assets/css/login.css
+++ b/extra-assets/css/login.css
@@ -19,6 +19,11 @@
     font-weight: bold;
 }
 
+[data-bs-theme="dark"] #operated-by a {
+    color: lightgray;
+    font-weight: bold;
+}
+
 #new-user {
     font-weight: bold;
 }

--- a/templates/login.html
+++ b/templates/login.html
@@ -57,41 +57,46 @@
 </div>
 
 <div class="container login-header" id="home" data-authenticator-login-url="{{authenticator_login_url}}">
-  <div class="logos col-md-12 text-center">
-    <img src="{{static_url("extra-assets/images/logos/nasa.png") }}" alt='NASA logo' height="96" />
-    <img src="{{static_url("extra-assets/images/logos/epa.svg") }}" alt='EPA logo' height="96" />
-    <img src="{{static_url("extra-assets/images/logos/nist.png") }}" alt='NIST logo' height="96" />
-    <img src="{{static_url("extra-assets/images/logos/noaa.png") }}" alt='NOAA logo' height="96" />
+  <div class="row">
+    <div class="logos col-12 text-center">
+      <img src="{{static_url('extra-assets/images/logos/nasa.png')}}" alt="NASA logo" height="96" />
+      <img src="{{static_url('extra-assets/images/logos/epa.svg')}}" alt="EPA logo" height="96" />
+      <img src="{{static_url('extra-assets/images/logos/nist.png')}}" alt="NIST logo" height="96" />
+      <img src="{{static_url('extra-assets/images/logos/noaa.png')}}" alt="NOAA logo" height="96" />
+    </div>
   </div>
 
-
-  <div class="col-md-8 col-md-push-2 card">
-      <h1 class="lead">
-      Welcome to the <a href="{{ custom.org.url }}">{{ custom.org.name }}</a> JupyterHub.
+  <div class="row justify-content-center mx-auto">
+    <div class="col-md-8 card border-0">
+      <h1 class="lead text-center">
+        Welcome to the <a href="{{ custom.org.url }}">{{ custom.org.name }}</a> JupyterHub.
       </h1>
       <p class="text-center">
         <span id="new-user"> New user? </span> Please see our documentation about <a href="https://us-ghg-center.github.io/ghgc-docs/services/jupyterhub.html">how to request access</a>.
       </p>
-    <div class="login-container text-center">
-      <a role="button" id="login-button" class='btn btn-jupyter btn-lg' href='{{authenticator_login_url}}'>
-        Log in to continue
-      </a>
+      <div class="login-container text-center">
+        <a role="button" id="login-button" class="btn btn-jupyter btn-lg" href="{{authenticator_login_url}}">
+          Log in to continue
+        </a>
+      </div>
     </div>
-  
   </div>
 
-    <div class="footer col-md-12">
-    <p>
-      This service is run transparently from <a href="https://github.com/2i2c-org/infrastructure">github.com/2i2c-org/infrastructure</a> by <a href="https://2i2c.org">2i2c.org</a>
-    </p>
-    <p>
-      Built with
-      <a href="https://k8s.org">Kubernetes</a>,
-      <a href="https://helm.sh">Helm</a>,
-      <a href="https://docker.com">Docker</a>,
-      <a href="https://github.com/conda-forge/miniforge">Miniforge</a> and
-      many parts of the <a href="https://jupyter.org">Jupyter Project</a>
+  <div class="row">
+    <div class="footer col-12 text-center">
+      <p>
+        This service is run transparently from <a href="https://github.com/2i2c-org/infrastructure">github.com/2i2c-org/infrastructure</a> by <a href="https://2i2c.org">2i2c.org</a>
       </p>
+      <p>
+        Built with
+        <a href="https://k8s.org">Kubernetes</a>,
+        <a href="https://helm.sh">Helm</a>,
+        <a href="https://docker.com">Docker</a>,
+        <a href="https://github.com/conda-forge/miniforge">Miniforge</a> and
+        many parts of the <a href="https://jupyter.org">Jupyter Project</a>
+      </p>
+    </div>
   </div>
 </div>
+
 {% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -31,23 +31,25 @@
 {% block main %}
 
 <!-- Modal -->
-<div class="modal fade" id="disclaimer-modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered" role="document">
+<div class="modal fade" id="disclaimer-modal" tabindex="-1" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
     <div class="modal-content">
       <div class="modal-body">
-        This US GHG Center JupyterHub environment is provided to authorized users for performing cloud analyses and to access data from the Center. Users are advised to review the documentation associated with any data they use. Access dataset documentation using the Data Catalog of the US GHG Center. 
+        This US GHG Center JupyterHub environment is provided to authorized users for performing cloud analyses and to access data from the Center. Users are advised to review the documentation associated with any data they use. Access dataset documentation using the Data Catalog of the US GHG Center.
       </div>
       <div class="modal-footer">
         <div class="container-fluid">
-          <div class="row">
-          <div class="col-md-5" style="text-align: left;">
-            <div class="form-check form-check-inline">
-              <input class="form-check-input" type="checkbox" id="disclaimer-modal-checkbox" checked>
-              <label class="form-check-label" for="disclaimer-modal-checkbox" style="font-weight: 300;">Don't show this again</label>
+          <div class="row align-items-center">
+            <div class="col-md-5 text-start">
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" id="disclaimer-modal-checkbox" checked>
+                <label class="form-check-label fw-light" for="disclaimer-modal-checkbox">Don't show this again</label>
+              </div>
+            </div>
+            <div class="col-md-7 text-end">
+              <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Close</button>
             </div>
           </div>
-          <div class="col-md-7"><button type="button" class="btn btn-primary" data-dismiss="modal">Close</button></div>
-        </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
As 2i2c upgraded the hubs to use JupyerHub5, we also had to migrate any UI we were maintaining away from older bootstrap versions (<5) .

As part of this upgrade, the ghg staging and prod hubs were updated to use the https://github.com/2i2c-org/default-hub-homepage/tree/bootstrap5-nasa-ghg-staging and https://github.com/2i2c-org/default-hub-homepage/tree/bootstrap5-nasa-ghg-prod branches instead of pulling from this repository.

https://github.com/2i2c-org/infrastructure/issues/5368 has more context.

This PR just brings the changes from the branches mentioned above to this repository, so we can update the hubs to this repository again and remain bootrap5 compatible.